### PR TITLE
Feature: Ignore spaces

### DIFF
--- a/src/CommonMark/Extension/Metadata/MetadataParser.php
+++ b/src/CommonMark/Extension/Metadata/MetadataParser.php
@@ -45,8 +45,10 @@ final class MetadataParser extends AbstractBlockContinueParser
         $line = $cursor->getLine();
         if ($line === '---') return BlockContinue::finished();
 
-        [$name, $value] = explode(':', $line);
-        $this->block->data->set(strtolower($name), $value);
+        if(!empty($line)) {
+            [$name, $value] = explode(':', $line);
+            $this->block->data->set(strtolower($name), $value);
+        }
 
         return BlockContinue::at($cursor);
     }

--- a/src/CommonMark/Extension/Metadata/MetadataParser.php
+++ b/src/CommonMark/Extension/Metadata/MetadataParser.php
@@ -47,7 +47,7 @@ final class MetadataParser extends AbstractBlockContinueParser
 
         if(!empty($line)) {
             [$name, $value] = explode(':', $line);
-            $this->block->data->set(strtolower($name), $value);
+            $this->block->data->set(strtolower(trim($name)), trim($value));
         }
 
         return BlockContinue::at($cursor);


### PR DESCRIPTION
Those two small changes add the following behaviour:

* ignore empty lines (before this change, empty lines led to errors)
* trim whitespace from variable-name & -value
